### PR TITLE
Kik 8266 improve travis build speed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-sudo: required
-dist: precise
+sudo: false
 language: android
 
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+sudo: required
+dist: precise
 language: android
 
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
     - $HOME/.gradle/daemon
     - $HOME/.android/build-cache
 
-    node_modules
+    - node_modules
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,24 +13,20 @@ cache:
     - $HOME/.gradle/daemon
     - $HOME/.android/build-cache
 
-#    - $TRAVIS_BUILD_DIR/truffle/node_modules
+    node_modules
 
 env:
   global:
     - ANDROID_API_LEVEL=26
-    - EMULATOR_API_LEVEL=21
+    - EMULATOR_API_LEVEL=16
 
 android:
   components:
   - tools
   - platform-tools
-  - tools
   - build-tools-26.0.2
-  - android-26
-  - android-21
-  - extra-google-m2repository
-  - extra-android-m2repository
-  - extra-android-support
+  - android-$ANDROID_API_LEVEL
+  - android-$EMULATOR_API_LEVEL
   - sys-img-armeabi-v7a-android-$ANDROID_API_LEVEL
   - sys-img-armeabi-v7a-android-$EMULATOR_API_LEVEL
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ export PATH := /usr/local/bin:$(PATH)
 
 test:
 	./gradlew :sample:assembleDebug
-	./gradlew --daemon :kin-sdk-core:connectedAndroidTest
+	./gradlew :kin-sdk-core:connectedAndroidTest
 .PHONY: test
 
 prepare-tests: truffle

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ export PATH := /usr/local/bin:$(PATH)
 
 test:
 	./gradlew :sample:assembleDebug
-	./gradlew :kin-sdk-core:connectedAndroidTest
+	./gradlew --daemon :kin-sdk-core:connectedAndroidTest
 .PHONY: test
 
 prepare-tests: truffle


### PR DESCRIPTION
- Improve Travis build by few minutes.
- comment out the node-modules dir for caching
- change emulator API level to 16.
   Few benchmarks I run, I could see this is the fastest emulator to power up.